### PR TITLE
Feature/begin end

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,10 +39,16 @@ git clone https://tpope.io/vim/repeat.git
 
 ## Usage
 
-By default, the plugin provides two mappings:
+By default, the plugin provides four mappings:
+> [optional param]
+> (param)
 
-- `<Leader>i` - Insert a character at the cursor position
-- `<Leader>a` - Insert a character after the cursor position
+> `[count]<bind>(char)`
+
+- `[count]<Leader>i(char)` - Insert a character at the cursor position
+- `[count]<Leader>a(char)` - Insert a character after the cursor position
+- `[count]<Leader>I(char)` - Insert a character at the beginning of the line
+- `[count]<Leader>A(char)` - Insert a character at the end of the line
 
 After pressing the mapping, you'll see a prompt asking for the character to insert. Press any character and it will be inserted without entering insert mode.
 
@@ -63,8 +69,13 @@ You can customize the plugin by setting these variables in your vimrc:
 
 ```vim
 " Change the mappings (before loading the plugin)
-let g:singlechar_map_insert_at = '<Leader>i'     " Default
-let g:singlechar_map_insert_after = '<Leader>a'  " Default
+let g:singlechar_map_insert_at = '<Leader>i'    " Default
+let g:singlechar_map_insert_after = '<Leader>a' " Default
+let g:singlechar_map_insert_begin = '<Leader>I' " Default
+let g:singlechar_map_insert_end = '<Leader>A'   " Default
+
+" Set the static cursor (no cursor move during singlechar actions)
+let g:singlechar_static_cursor = 1
 
 " Change the prompt message
 let g:singlechar_prompt = 'Press the character to insert - Press Esc to cancel...'  " Default
@@ -84,9 +95,14 @@ let g:singlechar_warning_message = 'Only the first character will be taken: {cha
 
 The plugin provides these commands:
 
-- `:InsertCharAt [count]` - Insert a character at the cursor position
-- `:InsertCharAfter [count]` - Insert a character after the cursor position
+> [optional param]
+> (param)
+
+- `:InsertCharAt (count) [char]` - Insert a character at the cursor position
+- `:InsertCharAfter (count) [char]` - Insert a character after the cursor position
+- `:InsertCharBegin (count) [char]` - Insert a character at the beginning of the line
+- `:InsertCharEnd (count) [char]` - Insert a character at the end of the line
 
 ## License
 
-MIT License
+[MIT License](https://github.com/lohhiiccc/vim-singlechar/blob/main/LICENSE)

--- a/autoload/singlechar.vim
+++ b/autoload/singlechar.vim
@@ -19,11 +19,10 @@ export def InsertChar(mode: string, count: number, input_char: string = ''): voi
         return
     endif
 
-    # Determine whether to insert before (i) or after (a) cursor
-    var insert_command = (mode ==# 'at') ? 'i' : 'a'
+    var insert_command = GetInsertCommand(mode)
     var insert_text = repeat(first_char, (count == 0) ? 1 : count)
 
-    execute 'normal! ' .. insert_command .. insert_text .. "\<Esc>"
+    DoSingleChar(insert_command, insert_text, g:singlechar_static_cursor)
     
     # Save last used values
     g:last_singlechar_key = first_char
@@ -35,6 +34,31 @@ export def InsertChar(mode: string, count: number, input_char: string = ''): voi
     if warning_message != ''
         redraw!
         echomsg warning_message
+    endif
+enddef
+
+def GetInsertCommand(mode: string): string
+    if mode ==# 'at'
+        return 'i'
+    elseif mode ==# 'after'
+        return 'a'
+    elseif mode ==# 'begin'
+        return 'I'
+    elseif mode ==# 'end'
+        return 'A'
+    else
+        return 'i'
+    endif
+enddef
+
+def DoSingleChar(command: string, text: string, resetCursor: number): void
+    var pos = getpos('.')
+    execute 'normal! ' .. command .. text .. "\<Esc>"
+    if resetCursor == 1
+        if (command ==# 'i')
+            pos[2] = pos[2] + 1
+        endif
+        setpos('.', pos)
     endif
 enddef
 

--- a/doc/singlechar.txt
+++ b/doc/singlechar.txt
@@ -6,7 +6,7 @@
 Author:       lohhiiccc
 Version:      1.0.0
 License:      MIT
-Last Change:  2025-08-19
+Last Change:  2025-08-21
 
 CONTENTS                                                     *singlechar-contents*
 
@@ -79,8 +79,10 @@ COMMANDS                                                    *singlechar-commands
 
 The plugin provides two commands:
 
-`:InsertCharAt [count]`   - Insert a character at the cursor position
-`:InsertCharAfter [count]` - Insert a character after the cursor position
+`:InsertCharAt [count] [char]`    - Insert a character at the cursor position
+`:InsertCharAfter [count] [char]` - Insert a character after the cursor position
+`:InsertCharBegin [count] [char]` - Insert a character at the beginning of the line
+`:InsertCharEnd [count] [char]`   - Insert a character at the end of the line
 
 The optional count parameter specifies how many times to insert the character.
 
@@ -89,8 +91,10 @@ MAPPINGS                                                    *singlechar-mappings
 
 By default, the plugin defines these mappings:
 
-`<Leader>i` - Map to `:InsertCharAt`
-`<Leader>a` - Map to `:InsertCharAfter`
+`[count]<Leader>i` - Map to `:InsertCharAt [count]`
+`[count]<Leader>a` - Map to `:InsertCharAfter [count]`
+`[count]<Leader>I` - Map to `:InsertCharBegin [count]`
+`[count]<Leader>A` - Map to `:InsertCharEnd [count]`
 
 ===============================================================================
 CONFIGURATION                                          *singlechar-configuration*
@@ -99,6 +103,8 @@ Customizing mappings: >
     " Must be set before the plugin is loaded
     let g:singlechar_map_insert_at = '<Leader>i'     " Default
     let g:singlechar_map_insert_after = '<Leader>a'  " Default
+    let g:singlechar_map_insert_begin = '<Leader>I'  " Default
+    let g:singlechar_map_insert_end = '<Leader>A'  " Default
 <
 Disabling default mappings: >
     " Disable default mappings
@@ -107,7 +113,13 @@ Disabling default mappings: >
     " Create your own mappings
     nnoremap <expr> <silent> ,i ":<C-u>InsertCharAt " .. v:count1 .. "<CR>"
     nnoremap <expr> <silent> ,a ":<C-u>InsertCharAfter " .. v:count1 .. "<CR>"
+    nnoremap <expr> <silent> ,I ":<C-u>InsertCharBegin " .. v:count1 .. "<CR>"
+    nnoremap <expr> <silent> ,A ":<C-u>InsertCharEnd " .. v:count1 .. "<CR>"
 <
+Set static cursor option: >
+    " When enabled, cursor returns to its original position after insertion
+    let g:singlechar_static_cursor = 1
+
 Changing the prompt message: >
     let g:singlechar_prompt = 'Character to insert (Esc to cancel): '
 <

--- a/plugin/singlechar.vim
+++ b/plugin/singlechar.vim
@@ -45,7 +45,7 @@ if !exists('g:singlechar_prompt')
   g:singlechar_prompt = 'Press the character to insert - Press Esc to cancel...'
 endif
 
-#Toggle off static cursor
+# Enable/disable static cursor feature
 if !exists('g:singlechar_static_cursor')
   g:singlechar_static_cursor = 0
 endif

--- a/plugin/singlechar.vim
+++ b/plugin/singlechar.vim
@@ -30,15 +30,32 @@ if !exists('g:singlechar_map_insert_after')
   g:singlechar_map_insert_after = '<Leader>a'
 endif
 
+# Mapping to insert a character at the endline
+if !exists('g:singlechar_map_insert_end')
+  g:singlechar_map_insert_end = '<Leader>A'
+endif
+
+# Mapping to insert a character at the startline
+if !exists('g:singlechar_map_insert_begin')
+  g:singlechar_map_insert_begin = '<Leader>I'
+endif
+
 # Prompt message shown when waiting for character input
 if !exists('g:singlechar_prompt')
   g:singlechar_prompt = 'Press the character to insert - Press Esc to cancel...'
 endif
 
+#Toggle static cursor
+if !exists('g:singlechar_static_cursor')
+  g:singlechar_static_cursor = 0
+endif
+
+# toggle warnign
 if !exists('g:singlechar_keylen_warning')
   g:singlechar_keylen_warning = 1
 endif
 
+# warning message
 if !exists('g:singlechar_warning_message')
   g:singlechar_warning_message = 'Only the first character will be taken: {char}'
 endif
@@ -54,6 +71,8 @@ g:last_singlechar_count = 1
 nnoremap <Plug>(singlechar-repeat) :call g:RepeatSingleChar()<CR>
 
 # Direct command implementations
+command! -count=1 -nargs=? InsertCharBegin singlechar.InsertChar('begin', <count>, <q-args>)
+command! -count=1 -nargs=? InsertCharEnd singlechar.InsertChar('end', <count>, <q-args>)
 command! -count=1 -nargs=? InsertCharAt singlechar.InsertChar('at', <count>, <q-args>)
 command! -count=1 -nargs=? InsertCharAfter singlechar.InsertChar('after', <count>, <q-args>)
 
@@ -61,6 +80,8 @@ command! -count=1 -nargs=? InsertCharAfter singlechar.InsertChar('after', <count
 if !exists('g:singlechar_no_mappings')
     execute 'nnoremap <expr> <silent> ' .. g:singlechar_map_insert_at .. ' ":<C-u>InsertCharAt " .. v:count1 .. "<CR>"' 
     execute 'nnoremap <expr> <silent> ' .. g:singlechar_map_insert_after .. ' ":<C-u>InsertCharAfter " .. v:count1 .. "<CR>"'
+    execute 'nnoremap <expr> <silent> ' .. g:singlechar_map_insert_begin .. ' ":<C-u>InsertCharBegin " .. v:count1 .. "<CR>"'
+    execute 'nnoremap <expr> <silent> ' .. g:singlechar_map_insert_end .. ' ":<C-u>InsertCharEnd " .. v:count1 .. "<CR>"'
 endif
 
 # Usage:

--- a/plugin/singlechar.vim
+++ b/plugin/singlechar.vim
@@ -50,7 +50,7 @@ if !exists('g:singlechar_static_cursor')
   g:singlechar_static_cursor = 0
 endif
 
-# toggle warnign
+# toggle warning
 if !exists('g:singlechar_keylen_warning')
   g:singlechar_keylen_warning = 1
 endif

--- a/plugin/singlechar.vim
+++ b/plugin/singlechar.vim
@@ -45,7 +45,7 @@ if !exists('g:singlechar_prompt')
   g:singlechar_prompt = 'Press the character to insert - Press Esc to cancel...'
 endif
 
-#Toggle static cursor
+#Toggle off static cursor
 if !exists('g:singlechar_static_cursor')
   g:singlechar_static_cursor = 0
 endif
@@ -85,10 +85,9 @@ if !exists('g:singlechar_no_mappings')
 endif
 
 # Usage:
-# <Leader>i - Insert character at cursor position
-# <Leader>a - Insert character after cursor position
+# [count]<Leader>i - Insert character at cursor position
+# [count]<Leader>I - Insert character at begin of the line
+# [count]<Leader>a - Insert character after cursor position
+# [count]<Leader>A - Insert character at end of the line
 # 
-# You can use a count before the mapping to insert multiple copies
-# of the same character. For example: 3<Leader>i will insert the
-# character 3 times at the cursor position.
 # ------------------------------------------------------------------------------ #


### PR DESCRIPTION
This pull request adds new functionality and improves configurability for the `vim-singlechar` plugin. Most notably, it introduces new commands and mappings to insert characters at the beginning and end of a line, and adds an option to keep the cursor static after insertion. Documentation and configuration options have been updated to reflect these changes.

### New features and functionality

* Added new commands `:InsertCharBegin` and `:InsertCharEnd` for inserting characters at the beginning and end of the line, respectively. Corresponding mappings `[count]<Leader>I` and `[count]<Leader>A` have also been added. [[1]](diffhunk://#diff-4a58eccd238093bbbbb0ad525d91c47b7da452db1b1a12cc682962ef1f08714fR74-L72) [[2]](diffhunk://#diff-7ecf286a65a62ff3716162098c9f142a2ece2f58768579b1fe7529e4f001a4f9R40-R64) [[3]](diffhunk://#diff-e0fe54db06837563528336cff6510d2c38d7437e1eb254a9f443f189cba6936dL82-R85) [[4]](diffhunk://#diff-e0fe54db06837563528336cff6510d2c38d7437e1eb254a9f443f189cba6936dL92-R97) [[5]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L42-R51) [[6]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L87-R108)
* Introduced the `g:singlechar_static_cursor` option, allowing users to keep the cursor at its original position after insertion. [[1]](diffhunk://#diff-7ecf286a65a62ff3716162098c9f142a2ece2f58768579b1fe7529e4f001a4f9R40-R64) [[2]](diffhunk://#diff-4a58eccd238093bbbbb0ad525d91c47b7da452db1b1a12cc682962ef1f08714fR33-R58) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R74-R78) [[4]](diffhunk://#diff-e0fe54db06837563528336cff6510d2c38d7437e1eb254a9f443f189cba6936dR116-R122)

### Documentation and configuration updates

* Updated documentation (`README.md` and `doc/singlechar.txt`) to include the new commands, mappings, and configuration options. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L42-R51) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R74-R78) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L87-R108) [[4]](diffhunk://#diff-e0fe54db06837563528336cff6510d2c38d7437e1eb254a9f443f189cba6936dL82-R85) [[5]](diffhunk://#diff-e0fe54db06837563528336cff6510d2c38d7437e1eb254a9f443f189cba6936dL92-R97) [[6]](diffhunk://#diff-e0fe54db06837563528336cff6510d2c38d7437e1eb254a9f443f189cba6936dR106-R107) [[7]](diffhunk://#diff-e0fe54db06837563528336cff6510d2c38d7437e1eb254a9f443f189cba6936dR116-R122)
* Added configuration options for the new mappings (`g:singlechar_map_insert_begin`, `g:singlechar_map_insert_end`) in the plugin setup. [[1]](diffhunk://#diff-4a58eccd238093bbbbb0ad525d91c47b7da452db1b1a12cc682962ef1f08714fR33-R58) [[2]](diffhunk://#diff-e0fe54db06837563528336cff6510d2c38d7437e1eb254a9f443f189cba6936dR106-R107)

### Codebase improvements

* Refactored insertion logic to use a new helper function `GetInsertCommand` for determining the correct Vim insert command, and `DoSingleChar` for handling insertion and cursor positioning. [[1]](diffhunk://#diff-7ecf286a65a62ff3716162098c9f142a2ece2f58768579b1fe7529e4f001a4f9L22-R25) [[2]](diffhunk://#diff-7ecf286a65a62ff3716162098c9f142a2ece2f58768579b1fe7529e4f001a4f9R40-R64)
* Updated plugin initialization to set sensible defaults for new options and mappings.

### Minor updates

* Updated the license link and last change date in documentation. [[1]](diffhunk://#diff-e0fe54db06837563528336cff6510d2c38d7437e1eb254a9f443f189cba6936dL9-R9) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L87-R108)